### PR TITLE
timestamp error in log db

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -69,7 +69,7 @@ CREATE TABLE Note(
 
 CREATE TABLE Log(
     machineID INTEGER NOT NULL AUTO_INCREMENT,
-    timestamp INTEGER NOT NULL,
+    timestamp DATETIME NOT NULL,
     operationalStatus VARCHAR(20) NOT NULL,
     maintenanceLog VARCHAR(100),
     errorCode VARCHAR(5),
@@ -168,7 +168,7 @@ INSERT INTO Note VALUES(
 
 INSERT INTO Log VALUES(
     999,
-    "01/04/2024 00:00",
+    "2024/04/01 00:00:00",
     "active",
     NULL,
     NULL,


### PR DESCRIPTION
fixed timestamp error in log table by changing it from integer to datetime and fixing format of insert to YYYY-MM-DD HH:MI:SS