### PR TITLE
Fixed up more of the factory landing page

### DIFF
--- a/scripts/factory.php
+++ b/scripts/factory.php
@@ -1,23 +1,44 @@
 <?php 
 function getStatus($result) {
     switch ($result) {
-        case 0: return "<text style='color: #7b68ee;'> Idle </text>";
-        case 1: return "<text style='color: #228b22;'> Active </text>";
-        case 2: return "<text style='color: #dc143c;'> Maintenance </text>";
-        default: return "<text style='color: #faf8f6;'> ERROR </text>";  // Something is wrong.
+        case 0: return "<text> Idle </text>";
+        case 1: return "<text> Active </text>";
+        case 2: return "<text> Maintenance </text>";
+        default: return "<text> ERROR </text>";  // Something is wrong.
     }
 }
 
-function appendMachineToList($assoc) {
-    echo '<li id="list-boxes">';
-        echo "<div class=\"listSmall-label\">{$assoc['name']}</div>"; //add {$assoc['machineID']} in brackets?
-        echo '<table class="machine-table">';
-            echo '<tr>';
-                echo "<td>Location: {$assoc['location']}</td>";
-            echo '<tr>';
-                echo "<td>Status: ", getStatus($assoc['status']), "</td>";
-            echo '<tr>';
-                echo "<td>Assigned PO: {$assoc['status']}</td>"; //need to see merged changes to db for assigned PO, join table statement?
-        echo '</table>';
-    echo '</li>';
+function getPO($result) {
+    if ($result) {
+        return $result;
+    } else {
+        return "<text> Vacant </text>";
+    }
+}
+
+function statusColor($result) {
+    switch ($result) {
+        case 0: return "#7b68ee";
+        case 1: return "#228b22";
+        case 2: return "#dc143c";
+        default: return "#faf8f6";  // Something is wrong.
+    }
+}
+
+if (!$assoc['isArchived']) {
+    function appendMachineToList($assoc) {
+        $background_colour = statusColor($assoc['status']);
+        $style = "background-color: $background_colour;";
+        echo '<li id="list-boxes">';
+            echo "<div style=\"$style\" class=\"listSmall-label\"> {$assoc['name']} </div>";
+            echo '<table class="machine-table">';
+                echo '<tr>';
+                    echo "<td>Location: {$assoc['location']}</td>";
+                echo '<tr>';
+                    echo "<td>Status: ", getStatus($assoc['status']), "</td>";
+                echo '<tr>';
+                    echo "<td>Assigned PO: ", getPO($assoc['assignedOperator']), "</td>";
+            echo '</table>';
+        echo '</li>';
+    }
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -115,11 +115,14 @@ h1 {
 }
     
 .listSmall-label { 
+    display: flex;
+    text-align: center !important; /* first element is not applying properly, issue with tables?? */
     font-weight: bold;
     font-size: 20px;
     padding: 0px 12px;
     width: 55%;
-    text-align: center;
+    align-items: center;
+    height: 100%;
 }
 
 #list-boxes {


### PR DESCRIPTION
Made the status colour to be the background of the label instead of just the status text, for better visibility and for consistency with the new machines page.

Made use of the assigned operator field in machines which has since been added since my previous pull request. If there is no one assigned, it states it as Vacant.

Archived machines are not added to the factory landing page.

Weird issue with the first line '3D Printer' seeming to not follow the 'text-align: center' property, but all the rest do. Not sure if you guys know a quick fix for that, as all I came across was that it could potentially be an issue with tables? But not sure why that would still be happening only to the first element.

So next would be to make each item clickable to re-direct to that machine's individual page for factory logs?