### PR TITLE
Fixed vertical scroll

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -9,7 +9,8 @@
 
 body {
     background-color: #fffafa;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto; /* scroll bar appears when page overflows off the bottom */
     width: 100%;
 }
 


### PR DESCRIPTION
Vertical scroll bar had been removed which meant that some pages which do not fit vertically were cut off and not accessible so I added the overflow-y: auto; to give those pages a scroll bar