### PR TITLE
Changing the Factory page based on Arran's suggestions over Discord

### DIFF
--- a/pages/factory.php
+++ b/pages/factory.php
@@ -16,7 +16,15 @@
     <div id=body-container-small>
         <h1>Factory Performance</h1> 
         <?php 
-            $sql = "SELECT * FROM Log WHERE timestamp = '2024-07-01 00:00' ORDER BY machineID;"; //Change query to be less cheaty, should be showing current timestamp no matter what
+            $sql = "SELECT l.*, m.name AS machineName
+                    FROM log l
+                    INNER JOIN (
+                        SELECT machineID, MAX(timestamp) as mostRecentTimestamp
+                        FROM log
+                        -- WHERE timestamp <= '2024-07-01 00:00'
+                        GROUP BY machineID
+                    ) r ON l.machineID = r.machineID AND l.timestamp = r.mostRecentTimestamp
+                    INNER JOIN Machine m ON l.machineID = m.machineID;"; 
             $result = mysqli_query($conn, $sql);
             if ($result && mysqli_num_rows($result)) {
                 echo '<ul class=listSmall>';

--- a/pages/factory.php
+++ b/pages/factory.php
@@ -6,12 +6,18 @@
     <meta name="author" content="Group 18" />
     <link rel="stylesheet" href="../styles/style.css">
     <script src="../scripts/banner.js"></script>
+    <script src="../scripts/factory.js"></script>
 </head>
 <body>
     <?php
         require_once '../include/page-defaults.php';
         require_once '../scripts/factory.php';
-        // require_once '../scripts/factory.js';
+        
+        date_default_timezone_set('Australia/Adelaide');
+        // Uses GET to set the disply time. Defaults to the current time. This is should be in the expected SQL format
+        $currentDisplayTimestamp = htmlspecialchars(isset($_GET['timestamp']) ? $_GET['timestamp'] : date('Y-m-d H:i:s'));
+        // Reformats to the format required for the datetime input i'll mention in a minute
+        $currentDisplayDateTimeLocal = date('Y-m-d\TH:i', strtotime($currentDisplayTimestamp));
         // mysqli_close($conn);
     ?>
     <div id=body-container-small>

--- a/pages/factory.php
+++ b/pages/factory.php
@@ -11,21 +11,27 @@
     <?php
         require_once '../include/page-defaults.php';
         require_once '../scripts/factory.php';
+        // require_once '../scripts/factory.js';
         // mysqli_close($conn);
     ?>
     <div id=body-container-small>
         <h1>Factory Performance</h1> 
         <?php 
+            // SQL query gets most recent log entry for each machine from supplied timestamp
             $sql = "SELECT l.*, m.name AS machineName
                     FROM log l
                     INNER JOIN (
                         SELECT machineID, MAX(timestamp) as mostRecentTimestamp
                         FROM log
-                        -- WHERE timestamp <= '2024-07-01 00:00'
+                        WHERE timestamp <= ?
                         GROUP BY machineID
                     ) r ON l.machineID = r.machineID AND l.timestamp = r.mostRecentTimestamp
                     INNER JOIN Machine m ON l.machineID = m.machineID;"; 
-            $result = mysqli_query($conn, $sql);
+            $stmt = mysqli_prepare($conn, $sql);
+            mysqli_stmt_bind_param($stmt, "s", $currentDisplayTimestamp);
+            mysqli_stmt_execute($stmt);
+            $result = mysqli_stmt_get_result($stmt);
+            // $result = mysqli_query($conn, $sql);
             if ($result && mysqli_num_rows($result)) {
                 echo '<ul class=listSmall>';
                 while ($assoc = mysqli_fetch_assoc($result)) {

--- a/pages/factory.php
+++ b/pages/factory.php
@@ -14,9 +14,9 @@
         // mysqli_close($conn);
     ?>
     <div id=body-container-small>
-        <h1>Factory Performance</h1>
+        <h1>Factory Performance</h1> 
         <?php 
-            $sql = "SELECT * FROM Machine ORDER BY machineID;";
+            $sql = "SELECT * FROM Log WHERE timestamp = '2024-07-01 00:00' ORDER BY machineID;"; //Change query to be less cheaty, should be showing current timestamp no matter what
             $result = mysqli_query($conn, $sql);
             if ($result && mysqli_num_rows($result)) {
                 echo '<ul class=listSmall>';
@@ -26,6 +26,9 @@
                 echo '</ul>';
                 mysqli_free_result($result);
             }
+            echo '<div id="machines-button-container">';
+                timeButtons();
+            echo '</div>';
             mysqli_close($conn);
         ?>
     </div>

--- a/scripts/factory.js
+++ b/scripts/factory.js
@@ -15,21 +15,23 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
-// Gets the current timestamp from the input
-const timestamp = document.getElementById('datetime-inp').value;
-// Convert to a Date object to access the methods
-let timestampDate = new Date(timestamp);
-// Stops setting time to the future (> current time)
-if(timestampDate.getTime() + (30* 60 * 1000) <= Date.now()) {
-    // Adds (or subtracts) 30 minutes (in milliseconds) to the timestamp
-    let newTime = new Date(timestampDate.setTime(timestampDate.getTime() + (30* 60 * 1000))); 
-    // Reformats the time back into the required format
-    const newFormattedTime = newTime.getFullYear() + "-" + (newTime.getMonth() + 1).toString().padStart(2, 0) + "-" + newTime.getDate().toString().padStart(2, 0) + "T" + 
-    newTime.getHours().toString().padStart(2, 0) + ":" + newTime.getMinutes().toString().padStart(2, 0);
-    //Updates the input with the new time
-    document.getElementById('datetime-inp').value = newFormattedTime;
-    // adds the new timestamp to the address bar
-    const QUERY_STRING = window.location.search;
-    const QUERY_PARAMETERS = new URLSearchParams(QUERY_STRING);
-    window.location.href = `?timestamp=${newFormattedTime}&machineID=${QUERY_PARAMETERS.get("machineID")}` 
-};
+function addMinutes(minutes) {
+    // Gets the current timestamp from the input
+    const timestamp = document.getElementById('datetime-inp').value;
+    // Convert to a Date object to access the methods
+    let timestampDate = new Date(timestamp);
+    // Stops setting time to the future (> current time)
+    if(timestampDate.getTime() + (minutes * 60 * 1000) <= Date.now()) {
+        // Adds (or subtracts) 30 minutes (in milliseconds) to the timestamp
+        let newTime = new Date(timestampDate.setTime(timestampDate.getTime() + (minutes * 60 * 1000))); 
+        // Reformats the time back into the required format
+        const newFormattedTime = newTime.getFullYear() + "-" + (newTime.getMonth() + 1).toString().padStart(2, 0) + "-" + newTime.getDate().toString().padStart(2, 0) + "T" + 
+        newTime.getHours().toString().padStart(2, 0) + ":" + newTime.getMinutes().toString().padStart(2, 0);
+        //Updates the input with the new time
+        document.getElementById('datetime-inp').value = newFormattedTime;
+        // adds the new timestamp to the address bar
+        const QUERY_STRING = window.location.search;
+        const QUERY_PARAMETERS = new URLSearchParams(QUERY_STRING);
+        window.location.href = `?timestamp=${newFormattedTime}&machineID=${QUERY_PARAMETERS.get("machineID")}`;
+    }
+}

--- a/scripts/factory.js
+++ b/scripts/factory.js
@@ -1,0 +1,35 @@
+function setTimestamp() {
+    // Gets the current timestamp from the input
+    const timestamp = document.getElementById('datetime-inp').value;
+    const QUERY_STRING = window.location.search;
+    const QUERY_PARAMETERS = new URLSearchParams(QUERY_STRING);
+    // adds the timestamp to the address bar
+    window.location.href = `?timestamp=${timestamp}&machineID=${QUERY_PARAMETERS.get("machineID")}`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const datetimeInput = document.getElementById('datetime-inp');
+    const datetimeWrapper = document.getElementById('datetime-inp-wrapper');
+    datetimeWrapper.addEventListener('click', () => {
+    datetimeInput.showPicker();
+    });
+});
+
+// Gets the current timestamp from the input
+const timestamp = document.getElementById('datetime-inp').value;
+// Convert to a Date object to access the methods
+let timestampDate = new Date(timestamp);
+// Stops setting time to the future (> current time)
+if(timestampDate.getTime() + (30* 60 * 1000) <= Date.now()) {
+    // Adds (or subtracts) 30 minutes (in milliseconds) to the timestamp
+    let newTime = new Date(timestampDate.setTime(timestampDate.getTime() + (30* 60 * 1000))); 
+    // Reformats the time back into the required format
+    const newFormattedTime = newTime.getFullYear() + "-" + (newTime.getMonth() + 1).toString().padStart(2, 0) + "-" + newTime.getDate().toString().padStart(2, 0) + "T" + 
+    newTime.getHours().toString().padStart(2, 0) + ":" + newTime.getMinutes().toString().padStart(2, 0);
+    //Updates the input with the new time
+    document.getElementById('datetime-inp').value = newFormattedTime;
+    // adds the new timestamp to the address bar
+    const QUERY_STRING = window.location.search;
+    const QUERY_PARAMETERS = new URLSearchParams(QUERY_STRING);
+    window.location.href = `?timestamp=${newFormattedTime}&machineID=${QUERY_PARAMETERS.get("machineID")}` 
+};

--- a/scripts/factory.php
+++ b/scripts/factory.php
@@ -17,12 +17,6 @@ function getSpeed($result) {
     }
 }
 
-date_default_timezone_set('Australia/Adelaide');
-// Uses GET to set the disply time. Defaults to the current time. This is should be in the expected SQL format
-$currentDisplayTimestamp = htmlspecialchars(isset($_GET['timestamp']) ? $_GET['timestamp'] : date('Y-m-d H:i:s'));
-// Reformats to the format required for the datetime input i'll mention in a minute
-$currentDisplayDateTimeLocal = date('Y-m-d\TH:i', strtotime($currentDisplayTimestamp));
-
     function appendMachineToList($assoc) {
         $background_colour = statusColor($assoc['operationalStatus']);
         $style = "background-color: $background_colour;";
@@ -54,17 +48,19 @@ function timeButtons() {
 }
 
 function lower30() { //Reduces timestamp in SQL query by 30mins? Then re-build list? How to minus from a timestamp string?
-    $sql = "SELECT DATEADD(MINUTE, -30, mostRecentTimestamp)";
-    echo "<a class=\"machines-button\"> -30 Minutes </a>";
+    // $sql = "SELECT DATEADD(MINUTE, -30, mostRecentTimestamp)";
+    echo "<button onclick='addMinutes(-30)' class=\"machines-button\"> -30 Minutes </button>";
 }
 
 function selectDate() {
     // echo "<a class=\"machines-button\"> Select Date </a>";
+    echo '<div id="datetime-inp-wrapper">';
     echo '<input class="machines-button" id="datetime-inp" type="datetime-local" value="$currentDisplayDateTimeLocal" onchange="setTimestamp()">';
+    echo '</div>';
 }
 
 function higher30() {
-    $current_time = new DateTime('2024-07-01 23:30'); 
-    $new_time = date_modify($current_time, '+30 minutes');
-    echo "<a class=\"machines-button\"> + 30 Minutes </a>";
+    // $current_time = new DateTime('2024-07-01 23:30'); 
+    // $new_time = date_modify($current_time, '+30 minutes');
+    echo "<button onclick='addMinutes(30)' class=\"machines-button\"> + 30 Minutes </button>";
 }

--- a/scripts/factory.php
+++ b/scripts/factory.php
@@ -17,10 +17,16 @@ function getSpeed($result) {
     }
 }
 
+date_default_timezone_set('Australia/Adelaide');
+// Uses GET to set the disply time. Defaults to the current time. This is should be in the expected SQL format
+$currentDisplayTimestamp = htmlspecialchars(isset($_GET['timestamp']) ? $_GET['timestamp'] : date('Y-m-d H:i:s'));
+// Reformats to the format required for the datetime input i'll mention in a minute
+$currentDisplayDateTimeLocal = date('Y-m-d\TH:i', strtotime($currentDisplayTimestamp));
+
     function appendMachineToList($assoc) {
         $background_colour = statusColor($assoc['operationalStatus']);
         $style = "background-color: $background_colour;";
-        echo '<li id="list-boxes">';
+        echo '<li class="list-boxes">';
             echo "<div style=\"$style\" class=\"listSmall-label\"> {$assoc['machineName']} </div>";
             echo '<table class="machine-table">';
                 echo '<tr>';
@@ -52,10 +58,13 @@ function lower30() { //Reduces timestamp in SQL query by 30mins? Then re-build l
     echo "<a class=\"machines-button\"> -30 Minutes </a>";
 }
 
-function selectDate() { //Use datetime input like in reports?
-    echo "<a class=\"machines-button\"> Select Date </a>";
+function selectDate() {
+    // echo "<a class=\"machines-button\"> Select Date </a>";
+    echo '<input class="machines-button" id="datetime-inp" type="datetime-local" value="$currentDisplayDateTimeLocal" onchange="setTimestamp()">';
 }
 
 function higher30() {
+    $current_time = new DateTime('2024-07-01 23:30'); 
+    $new_time = date_modify($current_time, '+30 minutes');
     echo "<a class=\"machines-button\"> + 30 Minutes </a>";
 }

--- a/scripts/factory.php
+++ b/scripts/factory.php
@@ -16,29 +16,76 @@ function getPO($result) {
     }
 }
 
+function getSpeed($result) {
+    if ($result) {
+        return $result;
+    } else {
+        return "N/A";
+    }
+}
+
+function getName($result) { //Need this as an SQL query so it doesn't break when adding a new machine, use the solution in reports?
+    switch($result) {
+        case 1: return "<text> 3D Printer </text>";
+        case 2: return "<text> Automated Assembly Line </text>";
+        case 3: return "<text> Automated Guided Vehicle (AGV) </text>";
+        case 4: return "<text> CNC Machine </text>";
+        case 5: return "<text> Energy Management System </text>";
+        case 6: return "<text> IoT Sensor Hub </text>";
+        case 7: return "<text> Industrial Robot </text>";
+        case 8: return "<text> Predictive Maintenance System </text>";
+        case 9: return "<text> Quality Control Scanner </text>";
+        case 10: return "<text> Smart Conveyor System </text>";
+    }
+}
+
 function statusColor($result) {
     switch ($result) {
-        case 0: return "#7b68ee";
-        case 1: return "#228b22";
-        case 2: return "#dc143c";
+        case 'idle': return "#7b68ee";
+        case 'active': return "#228b22";
+        case 'maintenance': return "#dc143c";
         default: return "#faf8f6";  // Something is wrong.
     }
 }
 
-if (!$assoc['isArchived']) {
     function appendMachineToList($assoc) {
-        $background_colour = statusColor($assoc['status']);
+        $background_colour = statusColor($assoc['operationalStatus']);
         $style = "background-color: $background_colour;";
         echo '<li id="list-boxes">';
-            echo "<div style=\"$style\" class=\"listSmall-label\"> {$assoc['name']} </div>";
+            echo "<div style=\"$style\" class=\"listSmall-label\">", getName($assoc['machineID']), "</div>"; //Use 'getMachineNames()' function like in reports?
             echo '<table class="machine-table">';
                 echo '<tr>';
-                    echo "<td>Location: {$assoc['location']}</td>";
+                    echo "<td>Production: {$assoc['productionCount']} </td>";
                 echo '<tr>';
-                    echo "<td>Status: ", getStatus($assoc['status']), "</td>";
+                    echo "<td style='color: darkgrey;'>Power: {$assoc['powerConsumption']} </td>";
                 echo '<tr>';
-                    echo "<td>Assigned PO: ", getPO($assoc['assignedOperator']), "</td>";
+                    echo "<td>Humidity: {$assoc['humidity']}</td>";
+                echo '<tr>';
+                    echo "<td style='color: darkgrey;'>Pressure: {$assoc['pressure']} </td>";
+                echo '<tr>';
+                    echo "<td>Vibration: {$assoc['vibration']} </td>";
+                echo '<tr>';
+                    echo "<td style='color: darkgrey;'>Speed: ", getSpeed($assoc['speed']), "</td>";
+                echo '<tr>';
+                    echo "<td>Temperature: {$assoc['temperature']} </td>";
             echo '</table>';
         echo '</li>';
     }
+
+function timeButtons() {
+    lower30();
+    selectDate();
+    higher30();
+}
+
+function lower30() { //Reduces timestamp in SQL query by 30mins? Then re-build list?
+    echo "<a class=\"machines-button\"> -30 Minutes </a>";
+}
+
+function selectDate() { //Use datetime input like in reports?
+    echo "<a class=\"machines-button\"> Select Date </a>";
+}
+
+function higher30() {
+    echo "<a class=\"machines-button\"> + 30 Minutes </a>";
 }

--- a/scripts/factory.php
+++ b/scripts/factory.php
@@ -1,18 +1,11 @@
 <?php 
-function getStatus($result) {
-    switch ($result) {
-        case 0: return "<text> Idle </text>";
-        case 1: return "<text> Active </text>";
-        case 2: return "<text> Maintenance </text>";
-        default: return "<text> ERROR </text>";  // Something is wrong.
-    }
-}
 
-function getPO($result) {
-    if ($result) {
-        return $result;
-    } else {
-        return "<text> Vacant </text>";
+function statusColor($result) {
+    switch ($result) {
+        case 'idle': return "#7b68ee";
+        case 'active': return "#228b22";
+        case 'maintenance': return "#dc143c";
+        default: return "#faf8f6";  // Something is wrong.
     }
 }
 
@@ -24,35 +17,11 @@ function getSpeed($result) {
     }
 }
 
-function getName($result) { //Need this as an SQL query so it doesn't break when adding a new machine, use the solution in reports?
-    switch($result) {
-        case 1: return "<text> 3D Printer </text>";
-        case 2: return "<text> Automated Assembly Line </text>";
-        case 3: return "<text> Automated Guided Vehicle (AGV) </text>";
-        case 4: return "<text> CNC Machine </text>";
-        case 5: return "<text> Energy Management System </text>";
-        case 6: return "<text> IoT Sensor Hub </text>";
-        case 7: return "<text> Industrial Robot </text>";
-        case 8: return "<text> Predictive Maintenance System </text>";
-        case 9: return "<text> Quality Control Scanner </text>";
-        case 10: return "<text> Smart Conveyor System </text>";
-    }
-}
-
-function statusColor($result) {
-    switch ($result) {
-        case 'idle': return "#7b68ee";
-        case 'active': return "#228b22";
-        case 'maintenance': return "#dc143c";
-        default: return "#faf8f6";  // Something is wrong.
-    }
-}
-
     function appendMachineToList($assoc) {
         $background_colour = statusColor($assoc['operationalStatus']);
         $style = "background-color: $background_colour;";
         echo '<li id="list-boxes">';
-            echo "<div style=\"$style\" class=\"listSmall-label\">", getName($assoc['machineID']), "</div>"; //Use 'getMachineNames()' function like in reports?
+            echo "<div style=\"$style\" class=\"listSmall-label\"> {$assoc['machineName']} </div>";
             echo '<table class="machine-table">';
                 echo '<tr>';
                     echo "<td>Production: {$assoc['productionCount']} </td>";
@@ -78,7 +47,8 @@ function timeButtons() {
     higher30();
 }
 
-function lower30() { //Reduces timestamp in SQL query by 30mins? Then re-build list?
+function lower30() { //Reduces timestamp in SQL query by 30mins? Then re-build list? How to minus from a timestamp string?
+    $sql = "SELECT DATEADD(MINUTE, -30, mostRecentTimestamp)";
     echo "<a class=\"machines-button\"> -30 Minutes </a>";
 }
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -175,7 +175,7 @@ h1 {
     /* height: fit-content; */
     height: 52vh;
     margin: -18px auto 24px auto;
-    width: 80%;
+    width: 64%; /* 80% */
     overflow-y: scroll;
 }
 
@@ -205,6 +205,8 @@ h1 {
     margin: 24px 0px;
     overflow: hidden;
     text-align: left;
+    margin-inline-start: 1.5%;
+    margin-bottom: 0.5%;
 }
     
 .listSmall-label { 
@@ -218,12 +220,10 @@ h1 {
     height: 100%;
 }
 
-#list-boxes {
-    width: 30%;
-    display: inline-flex;
-    vertical-align: top;
-    margin-right: 2em;
-    margin-bottom: 1.25em;
+.list-boxes {
+    width: 48%; /* 30% */
+    float: left;
+    position: relative;
 }
 
 .menu-item {
@@ -383,6 +383,7 @@ h1 {
     height: 100/3%;
     width: 100%;
     text-align-last: justify;
+    white-space: nowrap;
 }
 
 #body-container {

--- a/styles/style.css
+++ b/styles/style.css
@@ -172,9 +172,11 @@ h1 {
 }
 
 .listSmall {
-    height: fit-content;
-    margin: 0px auto 24px auto;
+    /* height: fit-content; */
+    height: 52vh;
+    margin: -18px auto 24px auto;
     width: 80%;
+    overflow-y: scroll;
 }
 
 .listSmall a {
@@ -198,7 +200,7 @@ h1 {
     border-radius: 6px;
     /* box-shadow: 0px 3px 3px 0px rgba(0, 0, 0, 0.226); */
     display: flex;
-    height: 120px;
+    height: 180px;
     list-style-type: none;
     margin: 24px 0px;
     overflow: hidden;
@@ -207,7 +209,7 @@ h1 {
     
 .listSmall-label { 
     display: flex;
-    text-align: center !important; /* first element is not applying properly, issue with tables?? */
+    text-align: center !important; /* not applying properly unless text goes over new line? */
     font-weight: bold;
     font-size: 20px;
     padding: 0px 12px;
@@ -220,7 +222,8 @@ h1 {
     width: 30%;
     display: inline-flex;
     vertical-align: top;
-    margin-right: 2.5em;
+    margin-right: 2em;
+    margin-bottom: 1.25em;
 }
 
 .menu-item {
@@ -376,7 +379,10 @@ h1 {
 
 .machine-table td {
     padding-left: 6px;
+    padding-right: 30px !important;
     height: 100/3%;
+    width: 100%;
+    text-align-last: justify;
 }
 
 #body-container {
@@ -391,7 +397,7 @@ h1 {
     height: fit-content;
     min-height: 60%;
     position: absolute;
-    top: 20vh;
+    top: 18vh;
     /* width: 80%; */
     width: fit-content;
     min-width: 100%;


### PR DESCRIPTION
Factory page is now displaying factory log data, and not its initial redundant parameters such as status, assigned PO, and location (which are all also displayed on the machines page).

The page still has the colour indicator for the machine status. The 7 quantitative fields from the Log data for each machine are displayed as they are in their current state (a.k.a. at the end of the csv). I have tried to order them with what a manager, or even the POs, would care for the most towards the top, with possible fields that could act as warning signs toward the bottom.

However, some of my code is cheating a little bit as I am getting quite confused about how similar functions have been implemented on the other pages. My SQL query for fetching the Log data is manually writing in the most up-to-date timestamp, instead of finding that out properly. I am also manually associating the names of the machines with their machineID, as I keep trying to implement the same getMachineName() function from the Reports page, but it keeps breaking and I'm not entirely sure where I am going wrong there. I also still haven't properly implemented the buttons at the bottom. I'd like to use the same date input from the Reports page as well, but I am getting very lost looking into that page. The +/- 30min buttons should also be implemented by adjusting the SQL query?

Apologies for not entirely finishing this page before the pull request, but I think I do need some help with the final pieces. I normally would like to bog down for a week and really research this properly, but especially with the presentation due so soon, I am hoping a little help from you guys could speed me up quite a lot.

Let me know if there are any styling issues with the spacing, last time seemed to be a bit sensitive and did not look the same as on my screen. There should be 3 columns.